### PR TITLE
Fixed the issue with the back button not working

### DIFF
--- a/static/script/appui/components/simplevideocomponent.js
+++ b/static/script/appui/components/simplevideocomponent.js
@@ -44,7 +44,6 @@ require.def("sampleapp/appui/components/simplevideocomponent",
                 // Get a reference to the current application and device objects
                 this._application = this.getCurrentApplication();
                 this._device = this._application.getDevice();
-                this._player;
 
                 // Create a a label add a class to it, this class can be used as a CSS selector
                 var description = new Label("Simple Video Component.");
@@ -96,27 +95,27 @@ require.def("sampleapp/appui/components/simplevideocomponent",
                 var videoType = "video/mp4";
 
                 // Create the device's video object, set the media sources and start loading the media
-                self._player = this.createVideoPlayer();
-                self._player.setSources([new VideoSource(videoUrl, videoType)]);
-                self._player.load();
+                var player = this.createVideoPlayer();
+                player.setSources([new VideoSource(videoUrl, videoType)]);
+                player.load();
             },
             getPlayer : function() {
                 return this._player;
             },
             destroyPlayer : function() {
-                self._player.destroy();
+                this._player.destroy();
                 this.removeChildWidget(this._player);
-                self._player = null;
+                this._player = null;
             },
             createVideoPlayer: function() {
-                //var self = this;
+                var self = this;
 
                 // Create the player and append it to the component
-                self._player = this._device.createMediaInterface('testPlayer', 'video');
-                this.appendChildWidget(self._player);
+                this._player = new Media('testPlayer', 'video');
+                this.appendChildWidget(this._player);
 
                 // Start playing the video as soon as the device fires an antie 'canplay' event
-                self._player.addEventListener('canplay', function(evt) {
+                this._player.addEventListener('canplay', function(evt) {
                     // Some devices have the player in the background behind the HTML page, we need to ensure the
                     // document body is transparent in order to see the video content
                     if (self._device.getPlayerEmbedMode() === Media.EMBED_MODE_BACKGROUND) {


### PR DESCRIPTION
On the example app, the simple video example does not work. the video doesn't play/pause (the video doesn't appear) etc and the back button doesn't work.

This is pull is to fix the back button so that the publicly visible example at least works on user interaction

(partially due to the method in device changing from ._device.createPlayer to _device.createMediaInterface)
