### PR TITLE
Adding basic rewind & fast forward buttons to SimpleVideoComponent

### DIFF
--- a/static/script/appui/components/simplevideocomponent.js
+++ b/static/script/appui/components/simplevideocomponent.js
@@ -67,6 +67,14 @@ require.def("sampleapp/appui/components/simplevideocomponent",
                     self.getPlayer().pause();
                 });
 
+		var rewind = new Button('rewind');
+                rewind.appendChildWidget(new Label('-5s'));
+                playerControlButtons.appendChildWidget(rewind);
+                rewind.addEventListener('select', function(evt) {
+		  var currentTime = self.getPlayer().getCurrentTime();
+                  self.getPlayer().setCurrentTime(currentTime - 5);
+                });
+
                 var back = new Button('back');
                 back.appendChildWidget(new Label('BACK'));
                 playerControlButtons.appendChildWidget(back);

--- a/static/script/appui/components/simplevideocomponent.js
+++ b/static/script/appui/components/simplevideocomponent.js
@@ -75,6 +75,14 @@ require.def("sampleapp/appui/components/simplevideocomponent",
                   self.getPlayer().setCurrentTime(currentTime - 5);
                 });
 
+	        var fastForward = new Button('fastForward');
+                fastForward.appendChildWidget(new Label('+5s'));
+		  playerControlButtons.appendChildWidget(fastForward);
+		  fastForward.addEventListener('select', function(evt) {
+		    var currentTime = self.getPlayer().getCurrentTime();
+		    self.getPlayer().setCurrentTime(currentTime + 5);
+                });
+
                 var back = new Button('back');
                 back.appendChildWidget(new Label('BACK'));
                 playerControlButtons.appendChildWidget(back);


### PR DESCRIPTION
Two small changes adding two new buttons to the SimpleVideoComponent, -5s and +5s.

The buttons call two simple functions which get the current time and add/subtract 5 seconds as appropriate. This value is then passed as a parameter to the `setCurrentTime` function. 