### PR TITLE
Fix brand/model overrides to work in Node server

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function returnResponse(url, response)
 	// Split the url in order to get the brand and model (if applicable)
 	if (url.search)
 	{
-		var parts = url.search.split("&");
+		var parts = url.search.replace(/^\?/, '').split("&");
 		var $_GET = {};
 		for (var i = 0; i < parts.length; i++) {
 			var temp = parts[i].split("=");
@@ -65,7 +65,7 @@ function returnResponse(url, response)
 		if ($_GET.brand) {
 			device_brand = $_GET.brand;
 		}
-		if ($_GET.model > -1) {
+		if ($_GET.model) {
 			device_model = $_GET.model;
 		}
 	}


### PR DESCRIPTION
Given a URL like:
http://localhost/talexample/?brand=enterprise&model=mainviewer

Model was not being overridden because of a dodgy 'if'. Brand was not being overridden if it was the first item in the query string. This fixes both of those bugs.