### PR TITLE
Listen on all interfaces, not just loopback

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,5 +194,5 @@ http.createServer(function (req, res) {
 
         break;
 	}
-}).listen(1337, '127.0.0.1');
-console.log('Server running at http://127.0.0.1:1337/');
+}).listen(1337);
+console.log('Server running on port 1337');


### PR DESCRIPTION
The Node server currently listens on the loopback interface only. This causes sadness if you're running it on one machine and accessing it elsewhere. This pull request resolves it by listening on all interfaces.

Feel free to fix the console message to display a best guess at the server's IP address - I couldn't be bothered.